### PR TITLE
fix(mqtt): use webpki-roots for TLS to prevent crash on Windows

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2168,7 +2168,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -4071,7 +4071,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -5689,6 +5689,7 @@ dependencies = [
  "tokio-util",
  "urlencoding",
  "uuid",
+ "webpki-roots 0.26.11",
  "window-vibrancy 0.7.1",
  "windows",
  "windows-core 0.61.2",
@@ -6477,6 +6478,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -39,6 +39,7 @@ tauri-plugin-global-shortcut = "2.3.1"
 window-vibrancy = "0.7.1"
 rumqttc = { version = "0.25.1", default-features = false, features = ["websocket", "use-rustls-no-provider", "url"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
+webpki-roots = "0.26"
 rayon = "1.10"
 
 regex = "1.12.2"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -16,6 +16,9 @@ use crate::global_state::*;
 use crate::app::setup;
 
 fn main() {
+    // 显式安装 rustls 的 crypto provider，防止 rumqttc 因缺少 provider 而 panic
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
     let _ = dotenvy::dotenv();
 
     let app = tauri::Builder::default()

--- a/src-tauri/src/services/mqtt_sub.rs
+++ b/src-tauri/src/services/mqtt_sub.rs
@@ -223,10 +223,78 @@ pub fn start_mqtt_client(app: AppHandle) {
                 };
 
                 // Apply transport settings explicitly for security
-                if use_wss {
-                    mqttoptions.set_transport(Transport::wss_with_default_config());
-                } else if use_tls {
-                    mqttoptions.set_transport(Transport::tls_with_default_config());
+                if use_wss || use_tls {
+                    // Manually build TlsConfiguration to avoid panic on invalid system certs
+                    // We only use webpki-roots which are safe and don't contain enterprise/AV certs that cause panic
+                    let mut root_store = rustls::RootCertStore::empty();
+                    root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+                    
+                    let mut config = rustls::ClientConfig::builder()
+                        .with_root_certificates(root_store)
+                        .with_no_client_auth();
+                        
+                    // If insecure flag is set, disable verification (dangerous but requested)
+                    if cfg.tls_insecure {
+                        #[derive(Debug)]
+                        struct NoVerifier;
+                        impl rustls::client::danger::ServerCertVerifier for NoVerifier {
+                            fn verify_server_cert(
+                                &self,
+                                _end_entity: &rustls::pki_types::CertificateDer<'_>,
+                                _intermediates: &[rustls::pki_types::CertificateDer<'_>],
+                                _server_name: &rustls::pki_types::ServerName<'_>,
+                                _ocsp_response: &[u8],
+                                _now: rustls::pki_types::UnixTime,
+                            ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+                                Ok(rustls::client::danger::ServerCertVerified::assertion())
+                            }
+
+                            fn verify_tls12_signature(
+                                &self,
+                                _message: &[u8],
+                                _cert: &rustls::pki_types::CertificateDer<'_>,
+                                _dss: &rustls::DigitallySignedStruct,
+                            ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+                                Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+                            }
+
+                            fn verify_tls13_signature(
+                                &self,
+                                _message: &[u8],
+                                _cert: &rustls::pki_types::CertificateDer<'_>,
+                                _dss: &rustls::DigitallySignedStruct,
+                            ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+                                Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+                            }
+                            
+                            fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+                                vec![
+                                    rustls::SignatureScheme::RSA_PKCS1_SHA1,
+                                    rustls::SignatureScheme::ECDSA_SHA1_Legacy,
+                                    rustls::SignatureScheme::RSA_PKCS1_SHA256,
+                                    rustls::SignatureScheme::ECDSA_NISTP256_SHA256,
+                                    rustls::SignatureScheme::RSA_PKCS1_SHA384,
+                                    rustls::SignatureScheme::ECDSA_NISTP384_SHA384,
+                                    rustls::SignatureScheme::RSA_PKCS1_SHA512,
+                                    rustls::SignatureScheme::ECDSA_NISTP521_SHA512,
+                                    rustls::SignatureScheme::RSA_PSS_SHA256,
+                                    rustls::SignatureScheme::RSA_PSS_SHA384,
+                                    rustls::SignatureScheme::RSA_PSS_SHA512,
+                                    rustls::SignatureScheme::ED25519,
+                                    rustls::SignatureScheme::ED448,
+                                ]
+                            }
+                        }
+                        config.dangerous().set_certificate_verifier(std::sync::Arc::new(NoVerifier));
+                    }
+
+                    if use_wss {
+                        // Use Rustls transport with Arc<ClientConfig>
+                        mqttoptions.set_transport(Transport::wss_with_config(config.into()));
+                    } else {
+                        // Use Rustls transport with Arc<ClientConfig>
+                        mqttoptions.set_transport(Transport::tls_with_config(config.into()));
+                    }
                 } else if use_ws {
                     mqttoptions.set_transport(Transport::ws());
                 }


### PR DESCRIPTION
- Manually configure rustls with webpki-roots to avoid loading system certificates that may contain unsupported critical extensions.
- Explicitly install rustls crypto provider in main.rs to prevent rumqttc panic.
- Fix debug implementation for NoVerifier.