### PR TITLE
fix: `Esc` close behavior

### DIFF
--- a/src-tauri/src/app/hooks/mod.rs
+++ b/src-tauri/src/app/hooks/mod.rs
@@ -212,10 +212,12 @@ pub unsafe extern "system" fn keyboard_proc(n_code: i32, w_param: WPARAM, l_para
 
              let is_navigation_key = vk == 0x26 || vk == 0x28 || vk == 0x0D || vk == 0x1B;
              let is_enter = vk == 0x0D;
-             let is_escape = vk == 0x1B;
+             let _is_escape = vk == 0x1B;
              
               if is_navigation_key && is_down {
-                   if (is_enter || is_escape) && !NAVIGATION_MODE_ACTIVE.load(Ordering::Relaxed) {
+                   // Only Enter requires navigation mode to be active
+                   // Escape can always close the window when it's visible
+                   if is_enter && !NAVIGATION_MODE_ACTIVE.load(Ordering::Relaxed) {
                        return CallNextHookEx(None, n_code, w_param, l_param);
                    }
                    let ctrl_down = (GetAsyncKeyState(VK_CONTROL.0 as i32) as u16 & 0x8000) != 0;

--- a/src/shared/hooks/useKeyboardNavigation.ts
+++ b/src/shared/hooks/useKeyboardNavigation.ts
@@ -92,18 +92,29 @@ export const useKeyboardNavigation = ({
       const isAnyInput = tagName === "INPUT" || tagName === "TEXTAREA";
       const isEditable = isAnyInput || target.isContentEditable === true;
 
-      if (isEditable) {
-        if (e.key === "Escape") {
-          searchInputRef.current?.blur();
+      if (e.key === "Escape") {
+          e.preventDefault();
+          if (isEditable) {
+              searchInputRef.current?.blur();
+          } else {
+              const isClipboardAtTop = !isKeyboardModeRef.current || selectedIndexRef.current <= 0;
+              if (isClipboardAtTop) {
+                invoke("hide_window_cmd");
+              } else {
+                setIsKeyboardMode(true);
+                setSelectedIndex(0);
+              }
+          }
           return;
-        }
+      }
 
-        if (e.key === "Enter" && isSearchInput) {
-          // Fall through
-        } else {
-          if (!arrowKeySelectionRef.current) return;
-          if (!isSearchInput) return;
-        }
+      if (isEditable) {
+          if (e.key === "Enter" && isSearchInput) {
+              // Fall through
+          } else {
+              if (!arrowKeySelectionRef.current) return;
+              if (!isSearchInput) return;
+          }
       }
 
       if (arrowKeySelectionRef.current && (e.key === "ArrowDown" || e.key === "ArrowUp")) {
@@ -115,6 +126,7 @@ export const useKeyboardNavigation = ({
             setSelectedIndex(0);
             return true;
           }
+
           if (e.key === "ArrowDown") {
             setSelectedIndex((s) => Math.min(s + 1, filteredHistoryRef.current.length - 1));
           } else {


### PR DESCRIPTION
Currently, when TieZ is invoked using the shortcut key, pressing Esc directly cannot close the pop-up window. This PR is designed to address this issue and align the performance of the clipboard on Windows.

>[!TIP]
> If in search mode, the first `Esc` will exit the mode, and the second `Esc` will close the Pop-Up window.