### PR TITLE
feat: 优化 3D 复古主题的视觉展示

### DIFF
--- a/src/features/clipboard/components/VirtualClipboardList.tsx
+++ b/src/features/clipboard/components/VirtualClipboardList.tsx
@@ -123,7 +123,7 @@ const VirtualClipboardList = React.forwardRef<VirtualClipboardListHandle, Virtua
         // Memoized item renderer for Virtuoso
         const itemContent = useCallback((index: number, item: ClipboardEntry) => {
             return (
-                <div style={{ paddingBottom: compactMode ? 2 : 4 }}>
+                <div style={{ paddingBottom: compactMode ? 6 : 12 }}>
                     {renderItem(item, index, index === 0)}
                 </div>
             );

--- a/src/styles/components/layout.css
+++ b/src/styles/components/layout.css
@@ -124,7 +124,8 @@ select.search-input option {
   padding: 6px 10px 4px 10px;
   /* Reduced from 8px 12px 6px 12px for higher density */
   background: var(--bg-element);
-  border: 3px solid var(--border-dark);
+  border: 1px solid var(--border-dark);
+  border-radius: 4px; /* Slight rounding for general themes by default */
   color: var(--text-primary);
   cursor: pointer;
   box-shadow: none;
@@ -139,6 +140,11 @@ select.search-input option {
   display: flex;
   flex-direction: column;
   box-sizing: border-box;
+}
+
+body.theme-retro .history-item {
+  border-radius: 0; /* Keep brutalist square edges for retro */
+  border: 2px solid rgba(128, 128, 128, 0.4);
 }
 
 


### PR DESCRIPTION
Fixes #12 

### 优化内容：
1. 将复古主题下过于厚重的 3px 黑色边框，调整为了符合复古物理感但更轻量的 `2px` 半透明边框（`rgba(128, 128, 128, 0.4)`）。
2. 为 VirtualClipboardList 的渲染增加了一定的动态 paddingBottom（非紧凑模式12px，紧凑模式6px），打破了列表原先密不透风的“砖墙”感，增加了视觉呼吸感。