### PR TITLE
fix: improve window drag performance on Windows

### DIFF
--- a/src/features/app/components/AppHeader.tsx
+++ b/src/features/app/components/AppHeader.tsx
@@ -13,7 +13,6 @@ import {
   X
 } from "lucide-react";
 import { invoke } from "@tauri-apps/api/core";
-import { getCurrentWindow } from "@tauri-apps/api/window";
 import { getTagColor } from "../../../shared/lib/utils";
 
 interface AppHeaderProps {
@@ -96,10 +95,8 @@ const AppHeader = ({
 
   return (
   <header
+    data-tauri-drag-region
     onMouseDown={(e) => {
-      // Only drag on left click
-      if (e.button !== 0) return;
-
       // Don't drag if clicking on interactive elements
       const target = e.target as HTMLElement;
       if (target.closest('button, input, select, textarea, [role="button"]')) {
@@ -110,10 +107,6 @@ const AppHeader = ({
       if (searchInputRef.current && document.activeElement === searchInputRef.current) {
         searchInputRef.current.blur();
       }
-
-      // Prevent default and start dragging
-      e.preventDefault();
-      getCurrentWindow().startDragging();
     }}
   >
     <div className="header-top">


### PR DESCRIPTION
## Problem
在 Windows 上拖动窗口时存在明显的延迟和不跟手的问题。

## Root Cause
`getCurrentWindow().startDragging()` 是一个 JS → IPC → Rust 的跨进程调用，每次鼠标按下时需要经过 IPC 通信，然后 Rust 端再调用 Windows API。这种实现在 Windows 上会导致：

1. IPC 通信开销
2. 消息循环延迟
3. 透明无边框窗口的处理更加复杂

## Solution
使用 Tauri 2 推荐的 `data-tauri-drag-region` HTML 属性替代 JS API：

```tsx
// Before
<header
  onMouseDown={(e) => {
    e.preventDefault();
    getCurrentWindow().startDragging();
  }}
>

// After
<header data-tauri-drag-region>
```

这种方式让 WebView2 直接处理拖动事件，避免了 IPC 往返，窗口拖动会更加流畅跟手。

## Changes
- 移除 `getCurrentWindow` 的 import
- 添加 `data-tauri-drag-region` 属性到 `<header>` 元素
- 移除不再需要的 `e.preventDefault()` 和 `startDragging()` 调用

## Testing
已在 Windows 10 上测试，窗口拖动流畅无延迟。