### PR TITLE
修复 Windows NSIS 卸载残留问题

### DIFF
--- a/src-tauri/nsis/uninstall.nsh
+++ b/src-tauri/nsis/uninstall.nsh
@@ -1,5 +1,20 @@
 !include "LogicLib.nsh"
 
+!macro NSIS_HOOK_PREUNINSTALL
+  DetailPrint "Stopping TieZ before uninstall..."
+
+  # 应用关闭主窗口时会缩到托盘，卸载器不能依赖普通的关闭请求。
+  # 这里在开始删除文件前强制结束已安装的进程，避免 exe 被占用。
+  nsExec::ExecToLog '"$SYSDIR\taskkill.exe" /F /T /IM TieZ.exe'
+  nsExec::ExecToLog '"$SYSDIR\taskkill.exe" /F /T /IM tiez-app.exe'
+  Sleep 1200
+
+  # 先清理常见的自启动注册表项，避免系统在卸载后继续拉起已删除的程序。
+  DeleteRegValue HKCU "Software\Microsoft\Windows\CurrentVersion\Run" "TieZ"
+  DeleteRegValue HKCU "Software\Microsoft\Windows\CurrentVersion\Run" "tie-z"
+  DeleteRegValue HKCU "Software\Microsoft\Windows\CurrentVersion\Run" "tiez-app"
+!macroend
+
 !macro NSIS_HOOK_POSTUNINSTALL
   DetailPrint "Restoring Windows Clipboard settings..."
   
@@ -35,6 +50,12 @@
   DeleteRegValue HKCU "Software\Microsoft\Windows\CurrentVersion\Policies\Explorer" "DisallowClipboardHistory"
   DeleteRegValue HKCU "Software\Policies\Microsoft\Windows\System" "AllowClipboardHistory"
   DeleteRegValue HKCU "Software\Policies\Microsoft\Windows\System" "AllowCrossDeviceClipboard"
+  DeleteRegValue HKCU "Software\Microsoft\Windows\CurrentVersion\Run" "TieZ"
+  DeleteRegValue HKCU "Software\Microsoft\Windows\CurrentVersion\Run" "tie-z"
+  DeleteRegValue HKCU "Software\Microsoft\Windows\CurrentVersion\Run" "tiez-app"
+  # 清理 NSIS 记录的上次安装路径，避免后续静默安装继续复用旧目录。
+  DeleteRegKey HKCU "Software\tiez\TieZ"
+  DeleteRegKey /ifempty HKCU "Software\tiez"
   
   DetailPrint "Windows Clipboard settings restored."
   
@@ -43,6 +64,12 @@
   DetailPrint "Restarting Explorer to apply changes..."
   nsExec::Exec '"powershell.exe" -NoProfile -WindowStyle Hidden -Command "Stop-Process -Name explorer -Force; Start-Process explorer"'
   DetailPrint "Explorer restarted."
+
+  # 5. 如果卸载时程序刚被关闭，或者 uninstall.exe 还没完全退出，
+  # NSIS 可能暂时删不掉安装目录。这里额外拉起一个后台清理助手，
+  # 等卸载器退出后再尝试删除残留目录和文件。
+  DetailPrint "Scheduling leftover install directory cleanup..."
+  nsExec::Exec '"$SYSDIR\cmd.exe" /C start "" /MIN powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -Command "Start-Sleep -Seconds 3; Stop-Process -Name TieZ,tiez-app -Force -ErrorAction SilentlyContinue; Remove-Item -LiteralPath ''$INSTDIR'' -Force -Recurse -ErrorAction SilentlyContinue"'
 !macroend
 
 # Function for string replacement (Uninstall version)


### PR DESCRIPTION
## 变更说明
- 卸载前强制结束 TieZ 相关进程，避免窗口缩到托盘后仍占用安装文件
- 卸载后清理自启动项与 NSIS 记录的安装路径，避免后续安装复用旧目录
- 增加延迟后台清理逻辑，兜底删除卸载后可能残留的安装目录
- 为新增卸载逻辑补充中文注释

## 验证情况
- 已本地构建 NSIS 安装包
- 已验证安装、启动、卸载流程
- 在用户可写目录下验证卸载后目录、卸载项和安装路径记录均被清理