### PR TITLE
fix(richtext): 修复富文本粘贴多余换行、空白丢失及实体解码问题

### DIFF
--- a/src-tauri/src/services/clipboard/utils.rs
+++ b/src-tauri/src/services/clipboard/utils.rs
@@ -460,15 +460,58 @@ fn normalize_plain_text_layout(text: &str) -> String {
 }
 
 fn decode_basic_html_entities(text: &str) -> String {
-    text.replace("&nbsp;", " ")
-        .replace("&#160;", " ")
-        .replace("&amp;", "&")
-        .replace("&lt;", "<")
-        .replace("&gt;", ">")
-        .replace("&quot;", "\"")
-        .replace("&#34;", "\"")
-        .replace("&#39;", "'")
-        .replace("&apos;", "'")
+    static HTML_ENTITY_RE: OnceLock<Regex> = OnceLock::new();
+
+    // Decode exactly one HTML entity layer. Chained replacements would turn
+    // visible text such as "&#32;" (represented by HTML as "&amp;#32;") into a
+    // space by decoding the newly-created entity a second time.
+    HTML_ENTITY_RE
+        .get_or_init(|| {
+            Regex::new(r"(?i)&(?:nbsp|amp|lt|gt|quot|apos|#x[0-9a-f]+|#[0-9]+);").unwrap()
+        })
+        .replace_all(text, |captures: &regex::Captures| {
+            let entity = captures.get(0).map(|m| m.as_str()).unwrap_or_default();
+            let lower = entity.to_ascii_lowercase();
+
+            match lower.as_str() {
+                "&nbsp;" => " ".to_string(),
+                "&amp;" => "&".to_string(),
+                "&lt;" => "<".to_string(),
+                "&gt;" => ">".to_string(),
+                "&quot;" => "\"".to_string(),
+                "&apos;" => "'".to_string(),
+                _ => {
+                    let digits = lower
+                        .strip_prefix("&#x")
+                        .and_then(|value| value.strip_suffix(';'));
+                    let value = if let Some(hex) = digits {
+                        u32::from_str_radix(hex, 16).ok()
+                    } else {
+                        lower
+                            .strip_prefix("&#")
+                            .and_then(|value| value.strip_suffix(';'))
+                            .and_then(|decimal| decimal.parse::<u32>().ok())
+                    };
+
+                    match value {
+                        Some(160) => " ".to_string(),
+                        Some(value) => char::from_u32(value)
+                            .map(|ch| ch.to_string())
+                            .unwrap_or_else(|| entity.to_string()),
+                        None => entity.to_string(),
+                    }
+                }
+            }
+        })
+        .into_owned()
+}
+
+fn contains_numeric_html_entity_literal(text: &str) -> bool {
+    static NUMERIC_ENTITY_RE: OnceLock<Regex> = OnceLock::new();
+
+    NUMERIC_ENTITY_RE
+        .get_or_init(|| Regex::new(r"(?i)&#(?:x[0-9a-f]+|[0-9]+);").unwrap())
+        .is_match(text)
 }
 
 fn is_office_style_definition_text(text: &str) -> bool {
@@ -1032,6 +1075,17 @@ pub fn derive_rich_text_content(content: &str, html_content: Option<&str>) -> St
         {
             return layout_plain;
         }
+
+        // Some clipboard producers expose visible text like "&#32;" verbatim in
+        // the plain-text flavor but fail to escape it as "&amp;#32;" in HTML.
+        // When decoding the plain text once produces the same visible HTML text,
+        // the plain flavor disambiguates the sequence as intentional literal text.
+        if contains_numeric_html_entity_literal(&sanitized_plain)
+            && collapse_preview_whitespace(&decode_basic_html_entities(&sanitized_plain))
+                == collapse_preview_whitespace(&text)
+        {
+            return sanitized_plain;
+        }
         return text;
     }
 
@@ -1550,6 +1604,52 @@ mod tests {
         let content = derive_rich_text_content("A\tB\nC\tD", Some(html));
 
         assert_eq!(content, "A\tB\nC\tD");
+    }
+
+    #[test]
+    fn rich_text_content_decodes_decimal_space_entity() {
+        let html = "<span>First&#32;Second</span>";
+
+        let content = derive_rich_text_content("First Second", Some(html));
+
+        assert_eq!(content, "First Second");
+        assert!(!content.contains("&#32;"));
+    }
+
+    #[test]
+    fn rich_text_content_decodes_hex_and_unicode_numeric_entities() {
+        let html = "<span>A&#x20;B&#20013;</span>";
+
+        let content = derive_rich_text_content("A B中", Some(html));
+
+        assert_eq!(content, "A B中");
+    }
+
+    #[test]
+    fn rich_text_content_does_not_double_decode_visible_numeric_entities() {
+        let html = "<span>&amp;#32; &amp;#x20;</span>";
+
+        let content = derive_rich_text_content("&#32; &#x20;", Some(html));
+
+        assert_eq!(content, "&#32; &#x20;");
+    }
+
+    #[test]
+    fn rich_text_content_uses_plain_text_to_disambiguate_unescaped_entity_literal() {
+        let html = "<span>First&#32;Second</span>";
+
+        let content = derive_rich_text_content("First&#32;Second", Some(html));
+
+        assert_eq!(content, "First&#32;Second");
+    }
+
+    #[test]
+    fn rich_text_content_keeps_invalid_numeric_entity_literal() {
+        let html = "<span>Value:&#99999999;</span>";
+
+        let content = derive_rich_text_content("Value:&#99999999;", Some(html));
+
+        assert_eq!(content, "Value:&#99999999;");
     }
 
     #[test]

--- a/src-tauri/src/services/clipboard/utils.rs
+++ b/src-tauri/src/services/clipboard/utils.rs
@@ -690,25 +690,134 @@ fn sanitize_rich_text_plain_text(text: &str) -> String {
 }
 
 fn extract_plain_text_from_htmlish(text: &str) -> String {
-    static BREAK_TAG_RE: OnceLock<Regex> = OnceLock::new();
     static TAG_RE: OnceLock<Regex> = OnceLock::new();
+    static HTML_SOURCE_WHITESPACE_RE: OnceLock<Regex> = OnceLock::new();
+    static NON_BREAKING_SPACE_ENTITY_RE: OnceLock<Regex> = OnceLock::new();
+    const EXPLICIT_LINE_BREAK: char = '\u{f0000}';
+    const PRESERVED_SPACE: char = '\u{f0001}';
+    const PRESERVED_TAB: char = '\u{f0002}';
 
     let repaired = strip_office_preview_noise(text);
     if repaired.is_empty() {
         return String::new();
     }
-    let with_breaks = BREAK_TAG_RE
-        .get_or_init(|| {
-            Regex::new(
-                r"(?is)</?(?:br|p|div|li|tr|td|th|table|h[1-6]|section|article|ul|ol)\b[^>]*>",
-            )
-            .unwrap()
-        })
-        .replace_all(&repaired, "\n");
-    let without_tags = TAG_RE
-        .get_or_init(|| Regex::new(r"(?is)<[^>]+>").unwrap())
-        .replace_all(with_breaks.as_ref(), " ");
-    let collapsed = normalize_plain_text_layout(&decode_basic_html_entities(without_tags.as_ref()));
+
+    let tag_re = TAG_RE.get_or_init(|| Regex::new(r"(?is)<[^>]+>").unwrap());
+    let mut with_breaks = String::with_capacity(repaired.len());
+    let mut cursor = 0;
+    let mut in_preformatted_block = false;
+
+    let append_text = |output: &mut String, fragment: &str, preserve_breaks: bool| {
+        if preserve_breaks {
+            let normalized = fragment.replace("\r\n", "\n").replace('\r', "\n");
+            for ch in normalized.chars() {
+                match ch {
+                    '\n' => output.push(EXPLICIT_LINE_BREAK),
+                    ' ' | '\u{a0}' => output.push(PRESERVED_SPACE),
+                    '\t' => output.push(PRESERVED_TAB),
+                    _ => output.push(ch),
+                }
+            }
+            return;
+        }
+
+        // Newlines used to format the HTML source are ordinary collapsible HTML
+        // whitespace, not visible line breaks. Only BRs, block boundaries and
+        // newlines inside PRE carry line-break semantics.
+        let protected = fragment.replace('\u{a0}', &PRESERVED_SPACE.to_string());
+        let collapsed = HTML_SOURCE_WHITESPACE_RE
+            .get_or_init(|| Regex::new(r"\s+").unwrap())
+            .replace_all(&protected, " ");
+        let text = if output.is_empty()
+            || output.ends_with('\n')
+            || output.ends_with(EXPLICIT_LINE_BREAK)
+        {
+            collapsed.trim_start_matches(' ')
+        } else {
+            collapsed.as_ref()
+        };
+        output.push_str(text);
+    };
+
+    let push_structural_break = |output: &mut String| {
+        while output.ends_with(' ') || output.ends_with('\t') {
+            output.pop();
+        }
+        if !output.is_empty() && !output.ends_with('\n') && !output.ends_with(EXPLICIT_LINE_BREAK) {
+            output.push('\n');
+        }
+    };
+
+    for tag_match in tag_re.find_iter(&repaired) {
+        append_text(
+            &mut with_breaks,
+            &repaired[cursor..tag_match.start()],
+            in_preformatted_block,
+        );
+        cursor = tag_match.end();
+
+        let raw_tag = tag_match.as_str();
+        let tag_body = raw_tag
+            .trim_start_matches('<')
+            .trim_start()
+            .trim_start_matches('/');
+        let tag_name = tag_body
+            .chars()
+            .take_while(|ch| ch.is_ascii_alphanumeric())
+            .collect::<String>()
+            .to_ascii_lowercase();
+        let is_closing = raw_tag
+            .trim_start_matches('<')
+            .trim_start()
+            .starts_with('/');
+
+        match tag_name.as_str() {
+            // Keep explicit BRs separate from structural boundaries while the
+            // layout normalizer collapses formatting-only blank lines. Restoring
+            // these markers afterwards preserves the exact number of explicit
+            // line breaks from the copied content.
+            "br" if !is_closing => with_breaks.push(EXPLICIT_LINE_BREAK),
+            // Cells are separated horizontally; the row closing tag supplies the
+            // line break. normalize_plain_text_layout later turns tabs into spaces.
+            "td" | "th" if is_closing => {
+                while with_breaks.ends_with(' ') {
+                    with_breaks.pop();
+                }
+                if !with_breaks.is_empty()
+                    && !with_breaks.ends_with('\n')
+                    && !with_breaks.ends_with('\t')
+                {
+                    with_breaks.push('\t');
+                }
+            }
+            "tr" if is_closing => push_structural_break(&mut with_breaks),
+            "p" | "div" | "li" | "table" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "section"
+            | "article" | "ul" | "ol" | "blockquote" | "pre" => {
+                // A block boundary is one logical break. Treating both the opening
+                // and closing tag as an unconditional newline produced \n\n between
+                // every pair of sibling blocks and at nested block boundaries.
+                push_structural_break(&mut with_breaks);
+            }
+            _ => {}
+        }
+
+        if tag_name == "pre" {
+            in_preformatted_block = !is_closing;
+        }
+    }
+    append_text(
+        &mut with_breaks,
+        &repaired[cursor..],
+        in_preformatted_block,
+    );
+
+    // Non-breaking spaces are commonly used to express visible indentation in
+    // rich text. Protect them before generic entity decoding and whitespace
+    // normalization so they do not get trimmed or collapsed.
+    let preserved_nbsp = NON_BREAKING_SPACE_ENTITY_RE
+        .get_or_init(|| Regex::new(r"(?i)&(?:nbsp|#0*160|#x0*a0);").unwrap())
+        .replace_all(&with_breaks, PRESERVED_SPACE.to_string());
+    let collapsed = normalize_plain_text_layout(&decode_basic_html_entities(&preserved_nbsp));
     let cleaned = strip_leading_office_metadata_text(&collapsed);
     if cleaned.is_empty() {
         return String::new();
@@ -717,6 +826,14 @@ fn extract_plain_text_from_htmlish(text: &str) -> String {
         String::new()
     } else {
         cleaned
+            .chars()
+            .map(|ch| match ch {
+                EXPLICIT_LINE_BREAK => '\n',
+                PRESERVED_SPACE => ' ',
+                PRESERVED_TAB => '\t',
+                _ => ch,
+            })
+            .collect()
     }
 }
 
@@ -894,6 +1011,7 @@ pub fn infer_rich_html_from_plain_text(
 }
 
 pub fn derive_rich_text_content(content: &str, html_content: Option<&str>) -> String {
+    let layout_plain = normalize_clipboard_plain_text(content);
     let sanitized_plain = sanitize_rich_text_plain_text(content);
     if looks_like_obsidian_callout_markdown(&sanitized_plain) {
         return sanitized_plain;
@@ -903,6 +1021,17 @@ pub fn derive_rich_text_content(content: &str, html_content: Option<&str>) -> St
         .map(extract_plain_text_from_htmlish)
         .filter(|text| !text.is_empty());
     if let Some(text) = html_text {
+        // The plain-text clipboard flavor already represents the rendered layout
+        // and is the most reliable source for indentation and repeated whitespace.
+        // Use it when its visible words match the cleaned HTML; noisy Office plain
+        // text still falls through to the HTML-derived result.
+        if !layout_plain.is_empty()
+            && !looks_like_html_fragment(&layout_plain)
+            && !is_office_style_definition_text(&collapse_preview_whitespace(&layout_plain))
+            && collapse_preview_whitespace(&layout_plain) == collapse_preview_whitespace(&text)
+        {
+            return layout_plain;
+        }
         return text;
     }
 
@@ -1325,6 +1454,102 @@ mod tests {
         let content = derive_rich_text_content(text, Some(html));
 
         assert_eq!(content, text);
+    }
+
+    #[test]
+    fn rich_text_content_does_not_double_break_between_paragraphs() {
+        let html = "<p>First</p><p>Second</p>";
+
+        let content = derive_rich_text_content("First\nSecond", Some(html));
+
+        assert_eq!(content, "First\nSecond");
+    }
+
+    #[test]
+    fn rich_text_content_collapses_nested_block_boundaries() {
+        let html = "<div><p>First</p></div><div><p>Second</p></div>";
+
+        let content = derive_rich_text_content("First\nSecond", Some(html));
+
+        assert_eq!(content, "First\nSecond");
+    }
+
+    #[test]
+    fn rich_text_content_ignores_html_source_formatting_newlines() {
+        let html = "<div>\n  <p>First</p>\n  <p>Second</p>\n</div>";
+
+        let content = derive_rich_text_content("First\nSecond", Some(html));
+
+        assert_eq!(content, "First\nSecond");
+    }
+
+    #[test]
+    fn rich_text_content_preserves_explicit_blank_line() {
+        let html = "<p>First</p><p><br></p><p>Second</p>";
+
+        let content = derive_rich_text_content("First\n\nSecond", Some(html));
+
+        assert_eq!(content, "First\n\nSecond");
+    }
+
+    #[test]
+    fn rich_text_content_preserves_multiple_explicit_line_breaks() {
+        let html = "<p>First<br><br><br>Second</p>";
+
+        let content = derive_rich_text_content("First\n\n\nSecond", Some(html));
+
+        assert_eq!(content, "First\n\n\nSecond");
+    }
+
+    #[test]
+    fn rich_text_content_preserves_multiple_preformatted_line_breaks() {
+        let html = "<pre>First\n\n\nSecond</pre>";
+
+        let content = derive_rich_text_content("First\n\n\nSecond", Some(html));
+
+        assert_eq!(content, "First\n\n\nSecond");
+    }
+
+    #[test]
+    fn rich_text_content_preserves_plain_text_indentation_when_html_words_match() {
+        let text = "    First\n\tSecond";
+        let html = "<div style=\"white-space: pre-wrap\">    First<br>\tSecond</div>";
+
+        let content = derive_rich_text_content(text, Some(html));
+
+        assert_eq!(content, text);
+    }
+
+    #[test]
+    fn rich_text_content_preserves_preformatted_spaces_and_tabs_without_plain_text() {
+        let html = "<pre>    First\n\tSecond</pre>";
+
+        let content = derive_rich_text_content("", Some(html));
+
+        assert_eq!(content, "    First\n\tSecond");
+    }
+
+    #[test]
+    fn rich_text_content_preserves_non_breaking_space_indentation() {
+        let html = "<div>&nbsp;&#160;&#xA0;Indented</div>";
+
+        let content = derive_rich_text_content("", Some(html));
+
+        assert_eq!(content, "   Indented");
+    }
+
+    #[test]
+    fn rich_text_content_preserves_plain_table_spacing_without_blank_rows() {
+        let html = concat!(
+            "<table>",
+            "<tr><td>A</td><td>B</td></tr>",
+            "<tr><td>C</td><td>D</td></tr>",
+            "</table>"
+        );
+
+        let content = derive_rich_text_content("A\tB\nC\tD", Some(html));
+
+        assert_eq!(content, "A\tB\nC\tD");
     }
 
     #[test]
@@ -2323,7 +2548,7 @@ pub fn parse_cf_html(raw: &[u8]) -> Option<String> {
 }
 
 #[cfg(test)]
-mod tests {
+mod content_detection_tests {
     use super::*;
 
     mod detect_content_type_tests {


### PR DESCRIPTION
## 背景

基于 Windows v0.3.3 修复富文本粘贴的两个问题：

1. HTML 转文本时，相邻或嵌套的块级标签可能叠加生成多余空行；后续空白归一化又可能误删复制内容原有的换行、空格和缩进。
2. 部分数字 HTML 实体未正确解码；另一方面，用户复制的字面文本 `&#32;` 不能被误转换为空格。

本次修复的原则是：**保留复制内容原有的空白布局，只避免富文本转换额外添加换行；实体只解码一层，并区分实体与字面文本。**

## 问题原因

### 富文本换行和空白

旧的 HTML 转文本逻辑会同时在块级元素的开始和结束标签处添加换行。相邻或嵌套标签可能因此产生重复换行，例如：

```html
<p>第一段</p><p>第二段</p>
```

单纯压缩转换结果中的空白也不合适：它无法判断哪些空白由标签额外生成，哪些是复制内容原有的多个换行、前导空格、连续空格或 Tab。

### 数字 HTML 实体

原有逻辑缺少通用的十进制和十六进制数字实体处理。同时，连续替换实体可能造成二次解码：用户可见的字面文本 `&#32;` 通常在 HTML 中写作 `&amp;#32;`；若先解码 `&amp;`，再解码新形成的 `&#32;`，字面文本就会错误地变成空格。

## 修改内容

### 保留原有空白，避免额外换行

- 区分 HTML 标签边界推导出的结构换行和内容本身的显式换行，避免相邻、嵌套块级标签重复添加空行。
- 当剪贴板纯文本与清理后的 HTML 可见内容一致时，保留纯文本原有布局，包括多个换行、前导及连续空格、Tab 和表格文本的行分隔。
- 纯文本包含 Office/WPS 元数据等不可靠内容时，仍可从 HTML 重建文本。
- 从 HTML 重建时，保留连续 `<br>`、`<pre>` 内的换行与缩进，以及 `&nbsp;`、`&#160;`、`&#xA0;` 表达的缩进；不把 HTML 源码自身的格式化缩进和换行误当成正文空行。

### 正确处理数字 HTML 实体

- 支持十进制和十六进制数字实体，例如 `&#32;`、`&#x20;` 转为空格，`&#20013;`、`&#x4E2D;` 转为“中”。
- 实体仅解码一层：HTML 中的 `&amp;#32;` 输出为字面文本 `&#32;`，不继续转换为空格。
- 对纯文本与 HTML 对字面数字实体表达不一致的剪贴板来源，利用纯文本内容消歧。
- 无效或超出 Unicode 范围的数字实体保持原样。

## Commit 划分

两个问题分别保留为独立 commit：

1. `9f07de9 fix(richtext): avoid extra line breaks in rich text`
2. `39f1f99 fix(richtext): decode numeric HTML entities`

## 验证情况

本次核对当前分支后，剪贴板工具模块测试结果为 **44 passed，0 failed**。测试覆盖：

- 相邻段落、嵌套块级元素及 HTML 源码格式化换行；
- 原有多个换行、前导空格、Tab、表格文本空白；
- 连续 `<br>`、`<pre>` 内空白和不换行空格缩进；
- 十进制、十六进制及 Unicode 数字实体；
- 字面量 `&#32;` 不被二次解码、非规范剪贴板来源的消歧，以及非法实体保持原样。

## 影响范围与验证边界

本次代码修改仅涉及 `src-tauri/src/services/clipboard/utils.rs`，主要影响富文本内容的文本提取，不涉及窗口逻辑、快捷键或界面交互。

自动化测试与 Windows NSIS 构建已完成；当前仅在Win11 x64环境上验证。